### PR TITLE
Handle errors and show message to users as notification

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,6 +39,7 @@
     }
   ],
   "permissions": [
-    "contextMenus"
+    "contextMenus",
+    "notifications"
   ]
 }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,10 +1,14 @@
+import { createTempNotification } from "./modules/notifications";
+
 let convertTZContextMenuItem = {
     "id": "convertTz",
     "title": "Convert to local",
     "contexts": ["all"]
 };
 
-chrome.contextMenus.create(convertTZContextMenuItem);
+chrome.runtime.onInstalled.addListener((details) => {
+    chrome.contextMenus.create(convertTZContextMenuItem);
+});
 
 chrome.contextMenus.onClicked.addListener((clickData, tab) => {
     if (clickData.menuItemId === 'convertTz') {
@@ -12,9 +16,17 @@ chrome.contextMenus.onClicked.addListener((clickData, tab) => {
         chrome.tabs.sendMessage(tab.id, 'convert_tz_context_menu_click_element_text', { frameId: clickData.frameId }, (response) => {
             if (chrome.runtime.lastError) {
                 console.log(chrome.runtime.lastError);
-                alert('An unexpected error occured');
+                createTempNotification(
+                    `CONTENT_SCRIPT_NOT_LOADED_${tab.id}`,
+                    'Unexpected Error',
+                    'Please reload page and try again'
+                );
             } else if (!response.ok) {
-                alert('Could not convert timezone');
+                createTempNotification(
+                    `CONVERT_TZ_ERROR_${tab.id}`,
+                    'Convert datetime failed',
+                    'Please reload page and try again'
+                );
             }
         });
     }

--- a/src/pages/Background/modules/notifications.js
+++ b/src/pages/Background/modules/notifications.js
@@ -1,0 +1,13 @@
+
+export function createTempNotification(notificationId, title, message, timeout = 2000) {
+    chrome.notifications.create(notificationId, {
+        type: 'basic',
+        iconUrl: 'icon-34.png',
+        title,
+        message
+    }, (notificationId) => {
+        setTimeout(() => {
+            chrome.notifications.clear(notificationId);
+        }, timeout);
+    });
+}


### PR DESCRIPTION
Error: `Could not establish connection. Receiving end does not exist.`
Cause of error: Content scripts not being loaded into existing tabs on extension installation

Solution:
Errors are being generated in background script, and background script cannot modify DOM to show error message. Used chrome notification to show temporary notifications with message to users